### PR TITLE
chore: update footer accent color

### DIFF
--- a/src/components/FooterBar.tsx
+++ b/src/components/FooterBar.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 
 export default function FooterBar() {
   return (
-    <footer className="footer-bar bg-[var(--background)] border-t border-[var(--color-lichen-gold)/30]">
+    <footer className="footer-bar bg-[var(--background)] border-t border-[var(--color-wattle-yellow)/30]">
       <div className="container mx-auto px-8 py-6">
         <div className="flex flex-col sm:flex-row justify-between items-center text-sm text-[var(--foreground)] gap-4 text-center sm:text-left">
           <div className="flex items-center gap-2">
@@ -11,7 +11,7 @@ export default function FooterBar() {
               This project is open source —{' '}
               <a
                 href="https://cassowary-world.sanity.studio/"
-                className="footer-link underline hover:text-[var(--color-lichen-gold)]"
+                className="footer-link underline hover:text-[var(--color-wattle-yellow)]"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -25,7 +25,7 @@ export default function FooterBar() {
               Want to contribute?{' '}
               <a
                 href="https://github.com/Crushford/cassowary-world"
-                className="footer-link underline hover:text-[var(--color-lichen-gold)]"
+                className="footer-link underline hover:text-[var(--color-wattle-yellow)]"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
## Summary
- use `var(--color-wattle-yellow)` for footer border and hover accents

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689373f1d95c832499b87a778facfcd9