### PR TITLE
Fix file tree visibility on mobile and add collapsible sidebar

### DIFF
--- a/src/app/lore/layout.tsx
+++ b/src/app/lore/layout.tsx
@@ -1,5 +1,5 @@
 import { getTree, getBranches } from '@/lib/github'
-import LoreNav from '@/components/LoreNav'
+import LoreSidebarPanel from '@/components/LoreSidebarPanel'
 
 export default async function LoreLayout({
   children,
@@ -9,17 +9,11 @@ export default async function LoreLayout({
   const [tree, branches] = await Promise.all([getTree(), getBranches()])
 
   return (
-    <div className="flex gap-8 py-6 min-h-screen">
-      {/* Sidebar */}
-      <aside
-        className="hidden lg:block w-56 xl:w-64 shrink-0 sticky top-6 self-start max-h-[calc(100vh-3rem)] overflow-y-auto"
-        style={{ borderRight: '1px solid var(--color-fern)', paddingRight: '1.5rem' }}
-      >
-        <LoreNav tree={tree} branches={branches} />
-      </aside>
+    <div className="flex flex-col lg:flex-row gap-0 lg:gap-8 py-6 min-h-screen">
+      <LoreSidebarPanel tree={tree} branches={branches} />
 
       {/* Content */}
-      <div className="flex-1 min-w-0">
+      <div className="flex-1 min-w-0 pt-4 lg:pt-0">
         {children}
       </div>
     </div>

--- a/src/components/LoreNav.tsx
+++ b/src/components/LoreNav.tsx
@@ -235,12 +235,16 @@ function NavNodeItem({
   branch,
   commit,
   depth,
+  expandedFolders,
+  toggleFolder,
 }: {
   node: NavNode
   currentUrl: string
   branch: string
   commit: string | null
   depth: number
+  expandedFolders: Set<string>
+  toggleFolder: (path: string) => void
 }) {
   const href = buildHref(node.urlPath, branch, commit)
   const isActive = currentUrl === node.urlPath
@@ -249,28 +253,33 @@ function NavNodeItem({
   if (node.isFolder && node.children.length === 0) return null
 
   if (node.isFolder) {
-    const hasActiveChild = node.children.some(c => hasActive(c, currentUrl))
+    const isExpanded = expandedFolders.has(node.filePath)
     return (
       <li>
-        <div
-          className="flex items-center gap-1.5 py-0.5 text-xs font-semibold uppercase tracking-wide opacity-50 mt-3"
-          style={{ paddingLeft: `${indent}px`, color: 'var(--foreground)' }}
+        <button
+          onClick={() => toggleFolder(node.filePath)}
+          className="flex items-center gap-1.5 py-0.5 text-xs font-semibold uppercase tracking-wide mt-3 w-full text-left hover:opacity-75 transition-opacity"
+          style={{ paddingLeft: `${indent}px`, color: 'var(--foreground)', opacity: 0.5 }}
         >
+          <span className="text-[10px] w-2.5 shrink-0">{isExpanded ? '▾' : '▸'}</span>
           <span>{node.name}</span>
-          {hasActiveChild && <span style={{ color: 'var(--color-fern)' }}>▸</span>}
-        </div>
-        <ul>
-          {node.children.map(child => (
-            <NavNodeItem
-              key={child.filePath}
-              node={child}
-              currentUrl={currentUrl}
-              branch={branch}
-              commit={commit}
-              depth={depth + 1}
-            />
-          ))}
-        </ul>
+        </button>
+        {isExpanded && (
+          <ul>
+            {node.children.map(child => (
+              <NavNodeItem
+                key={child.filePath}
+                node={child}
+                currentUrl={currentUrl}
+                branch={branch}
+                commit={commit}
+                depth={depth + 1}
+                expandedFolders={expandedFolders}
+                toggleFolder={toggleFolder}
+              />
+            ))}
+          </ul>
+        )}
       </li>
     )
   }
@@ -317,6 +326,7 @@ function LoreNavInner({
   const ref = commit ?? branch
 
   const [tree, setTree] = useState<TreeItem[]>(initialTree)
+  const [expandedFolders, setExpandedFolders] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     fetch(`/api/tree?ref=${ref}`)
@@ -326,6 +336,31 @@ function LoreNavInner({
   }, [ref])
 
   const nodes = buildTree(tree)
+
+  // Auto-expand folders that contain the current page
+  useEffect(() => {
+    const expanded = new Set<string>()
+    function markExpanded(nodeList: NavNode[]) {
+      for (const node of nodeList) {
+        if (node.isFolder && hasActive(node, pathname)) {
+          expanded.add(node.filePath)
+          markExpanded(node.children)
+        }
+      }
+    }
+    markExpanded(nodes)
+    setExpandedFolders(expanded)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, tree])
+
+  function toggleFolder(path: string) {
+    setExpandedFolders((prev: Set<string>) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }
 
   return (
     <nav className="text-sm">
@@ -349,6 +384,8 @@ function LoreNavInner({
             branch={branch}
             commit={commit}
             depth={0}
+            expandedFolders={expandedFolders}
+            toggleFolder={toggleFolder}
           />
         ))}
       </ul>

--- a/src/components/LoreSidebarPanel.tsx
+++ b/src/components/LoreSidebarPanel.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { type TreeItem } from '@/lib/github'
+import LoreNav from './LoreNav'
+
+export default function LoreSidebarPanel({
+  tree,
+  branches,
+}: {
+  tree: TreeItem[]
+  branches: string[]
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    if (window.innerWidth >= 1024) setIsOpen(true)
+  }, [])
+
+  return (
+    <aside
+      className="w-full lg:w-56 xl:w-64 shrink-0 lg:sticky lg:top-6 lg:self-start lg:max-h-[calc(100vh-3rem)] lg:overflow-y-auto lg:pr-6"
+      style={{ borderRight: isOpen ? '1px solid var(--color-fern)' : undefined } as React.CSSProperties}
+    >
+      {/* Toggle button */}
+      <button
+        onClick={() => setIsOpen((o: boolean) => !o)}
+        className="w-full flex items-center justify-between py-2 px-1 text-sm font-mono uppercase tracking-widest hover:opacity-100 transition-opacity"
+        style={{ color: 'var(--color-cassowary)', opacity: 0.75 }}
+        aria-expanded={isOpen}
+        aria-controls="lore-nav-panel"
+      >
+        <span>File Tree</span>
+        <span className="text-xs">{isOpen ? '▴' : '▾'}</span>
+      </button>
+
+      <div
+        id="lore-nav-panel"
+        className={isOpen ? 'block' : 'hidden'}
+        style={{ borderTop: '1px solid var(--color-fern)', paddingTop: '0.75rem' }}
+      >
+        <LoreNav tree={tree} branches={branches} />
+      </div>
+    </aside>
+  )
+}


### PR DESCRIPTION
- Replace hidden lg:block aside with LoreSidebarPanel client component
- Layout switches to flex-col on mobile, flex-row on desktop
- File Tree toggle button visible on all screen sizes; closed by default on mobile, open on desktop (via useEffect)
- Folder nodes in the tree are now click-to-expand/collapse with ▸/▾ indicators
- Active page's parent folders auto-expand on navigation

https://claude.ai/code/session_015r8TB6RdnTGSN666B2v6zd